### PR TITLE
added mastodon to the footer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -76,6 +76,11 @@ rendered_data_collapsed = false
 	icon = "fab fa-youtube"
   desc = "Matrix YouTube channel"
 [[params.links.developer]]
+	name = "Mastodon"
+	url = "https://mastodon.matrix.org/@matrix"
+	icon = "fab fa-mastodon"
+  desc = "Matrix on the Fediverse"
+[[params.links.developer]]
 	name = "Twitter"
 	url = "https://twitter.com/matrixdotorg"
 	icon = "fab fa-twitter"


### PR DESCRIPTION
We need to promote open alternatives to the closed source centralized jails. ;D
This would also be needed on the [matrix.org](https://matrix.org/) page.
**I didn't tried this out, but I think it should work.** 